### PR TITLE
Watchdog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # project specific
 conf/*
+.service_down
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 - screenshot to README
+- added `/api/health` endpoint to determine the running status of the main program loop. Returns _Offline_ if the main check loop hasn't run in 2 minutes - in theory this should run once every 60 seconds
 
 ### Changed
 
-- `SCRIPTS_PATH` template variable now points to [trash-panda-scripts](https://github.com/robweber/trash-panda-scripts) repo. Default location is same parent folder containing main repo. 
+- `SCRIPTS_PATH` template variable now points to [trash-panda-scripts](https://github.com/robweber/trash-panda-scripts) repo. Default location is same parent folder containing main repo.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - screenshot to README
 - added `/api/health` endpoint to determine the running status of the main program loop. Returns _Offline_ if the main check loop hasn't run in 2 minutes - in theory this should run once every 60 seconds
+- `watchdog.py` script that can be used to externally check if the service is healthy
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PEP8](https://img.shields.io/badge/code%20style-pep8-orange.svg)](https://www.python.org/dev/peps/pep-0008/)
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg)](https://github.com/RichardLitt/standard-readme)
 
-This is a _very_ basic monitoring solution meant for simple home use. It will monitor the status of some basic IP systems and services in a simple dashboard. Some basic service and device type definitions are supplied; however more can be added by altering the YAML configuration files. 
+This is a _very_ basic monitoring solution meant for simple home use. It will monitor the status of some basic IP systems and services in a simple dashboard. Some basic service and device type definitions are supplied; however more can be added by altering the YAML configuration files.
 
 ## Table of Contents
 
@@ -132,6 +132,15 @@ __/api/overall_status__ - a status summary of the overall status of all hosts
   "overall_status": 0,
   "overall_status_description": "OK",
   "total_hosts": 3
+}
+```
+
+__/api/health__ - basic program health. Status is set to _Offline_ if the main system checking loop hasn't run in over 2 minutes. This should look for services to check every 60 seconds when running properly.
+
+```
+{
+  "last_check_time": "07-05-2022 12:00PM", 
+  "status": "Online"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ __/api/health__ - basic program health. Status is set to _Offline_ if the main s
 
 ```
 {
-  "last_check_time": "07-05-2022 12:00PM", 
-  "status": "Online"
+  "last_check_time": "07-05-2022 12:00PM",
+  "text": "Online",
+  "return_code": 0
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This is a _very_ basic monitoring solution meant for simple home use. It will mo
   - [Service](#service)
   - [Script Paths](#script-paths)
   - [Custom Functions](#custom-functions)
+- [Watchdog](#watchdog)
 - [Credits](#credits)
 - [License](#license)
 
@@ -318,6 +319,16 @@ The following custom functions are available in addition to any standard [Jinja 
 
 * `path()` - this is a shortcut for the Python os.path.join() method to easily join paths together.
 * `default()` - allows for setting a default in cases where the user may or may not set a variable. If the user variable doesn't exist the default is used.
+
+## Watchdog
+
+Trash Panda will check if defined hosts and services are running, but what keeps track of Trash Panda? The `watchdog.py` script can be used to externally check the Trash Panda web service via the [health api](#api) endpoint. This script should be setup to run via a cron job and can read in the same YAML config file to trigger monitoring notifications. If the health service is either not running, or it reports that the monitoring system checker is not running, a notification will be sent using the configured notifier from the YAML file.
+
+```
+python3 watchdog.py -c conf/monitor.yaml
+```
+
+Once a notification is sent a flag file is created in the Trash Panda repo directory named `.service_down`. This file prevents further notifications and will be deleted when the Trash Panda service is restarted. 
 
 ## Credits
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -92,8 +92,8 @@ def webapp_thread(port_number, config_file, debugMode=False, logHandlers=[]):
 
         # check if the main program loop is running
         now = datetime.datetime.now()
-        if(now > last_check + datetime.timedelta(minutes=1)):
-            # program is offline if it hasn't run in a minute
+        if(now > last_check + datetime.timedelta(minutes=2)):
+            # program is offline if it hasn't run in 2 minutes (grace time for checks)
             status['status'] = 'Offline'
 
         return jsonify(status)

--- a/dashboard.py
+++ b/dashboard.py
@@ -267,6 +267,10 @@ webAppThread = threading.Thread(name='Web App', target=webapp_thread, args=(args
 webAppThread.setDaemon(True)
 webAppThread.start()
 
+# check if the watchdog file was created
+if(os.path.exists(utils.WATCHDOG_FILE)):
+    os.remove(utils.WATCHDOG_FILE)
+
 logging.info('Starting monitoring check daemon')
 monitor = HostMonitor(yaml_file)
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -13,6 +13,7 @@ sudo python3 dashboard.py -h
 
 import asyncio
 import configargparse
+import datetime
 import logging
 import signal
 import sys
@@ -264,4 +265,6 @@ while 1:
         # save the updated host
         history.save_host(host['id'], host)
 
+    # record the last time this loop ran
+    history.save_last_check()
     time.sleep(60)

--- a/dashboard.py
+++ b/dashboard.py
@@ -83,6 +83,21 @@ def webapp_thread(port_number, config_file, debugMode=False, logHandlers=[]):
             flash('Host page not found', 'warning')
             return redirect('/')
 
+    @app.route('/api/health', methods=['GET'])
+    def health():
+        """calculate the monitoring system health by making sure the main program
+        loop is running properly"""
+        last_check = history.get_last_check()
+        status = {"status": "Online", 'last_check_time': last_check.strftime(utils.TIME_FORMAT)}
+
+        # check if the main program loop is running
+        now = datetime.datetime.now()
+        if(now > last_check + datetime.timedelta(minutes=1)):
+            # program is offline if it hasn't run in a minute
+            status['status'] = 'Offline'
+
+        return jsonify(status)
+
     @app.route('/api/status', methods=['GET'])
     def status():
         # get a list of hosts

--- a/dashboard.py
+++ b/dashboard.py
@@ -88,13 +88,15 @@ def webapp_thread(port_number, config_file, debugMode=False, logHandlers=[]):
         """calculate the monitoring system health by making sure the main program
         loop is running properly"""
         last_check = history.get_last_check()
-        status = {"status": "Online", 'last_check_time': last_check.strftime(utils.TIME_FORMAT)}
+        status = {"text": "Online", "return_code": 0,
+                  'last_check_time': last_check.strftime(utils.TIME_FORMAT)}
 
         # check if the main program loop is running
         now = datetime.datetime.now()
         if(now > last_check + datetime.timedelta(minutes=2)):
             # program is offline if it hasn't run in 2 minutes (grace time for checks)
-            status['status'] = 'Offline'
+            status['text'] = 'Offline'
+            status['return_code'] = 2  # Critical status
 
         return jsonify(status)
 

--- a/modules/history.py
+++ b/modules/history.py
@@ -1,5 +1,7 @@
+import datetime
 import json
 import redis
+import modules.utils as utils
 from enum import Enum
 
 
@@ -10,6 +12,21 @@ class HostHistory:
 
     def __init__(self):
         self.db = redis.Redis('localhost', decode_responses=True)
+
+    def save_last_check(self):
+        """sets the last check time using the current time as a unix timestamp"""
+        now = datetime.datetime.now()
+
+        self.__write_db(DBKeys.LAST_CHECK.value, datetime.datetime.timestamp(now))
+
+    def get_last_check(self):
+        """returns the last check time saved in the DB
+
+        :returns: the last update time as a datetime object
+        """
+        last_update = datetime.datetime.fromtimestamp(self.__read_db(DBKeys.LAST_CHECK.value))
+
+        return last_update
 
     def list_hosts(self):
         return self.__read_db(DBKeys.VALID_HOSTS.value)
@@ -78,3 +95,4 @@ class DBKeys(Enum):
     """Enum that holds the keys for Redis data lookups"""
     VALID_HOSTS = "host_names"
     HOST_STATUS = "host_status"
+    LAST_CHECK = "last_check_timestamp"

--- a/modules/monitor.py
+++ b/modules/monitor.py
@@ -25,7 +25,6 @@ class HostMonitor:
     services = None
     hosts = None
     history = None
-    time_format = "%m-%d-%Y %I:%M%p"
     custom_jinja_constants = {}
     __jinja = None
 
@@ -57,7 +56,7 @@ class HostMonitor:
 
             # set the next check time - randomize a bit to save on load
             next_check_random = next_check + datetime.timedelta(seconds=randint(-60, 60))
-            device.next_check = next_check_random.strftime(self.time_format)
+            device.next_check = next_check_random.strftime(utils.TIME_FORMAT)
             self.hosts.append(device)
             logging.info(f"Loading device {device.name} with check interval every {device.interval} min")
 
@@ -185,7 +184,7 @@ class HostMonitor:
         service_id = slugify(name)
         now = datetime.datetime.now()
         result = {"name": name, "return_code": return_code, "text": text, "id": service_id,
-                 "check_attempt": 1, "state": utils.CONFIRMED_STATE, "last_state_change": now.strftime(self.time_format)}
+                 "check_attempt": 1, "state": utils.CONFIRMED_STATE, "last_state_change": now.strftime(utils.TIME_FORMAT)}
 
         if(url.strip() != ""):
             result['service_url'] = url
@@ -231,7 +230,7 @@ class HostMonitor:
             aHost = self.hosts[i]
 
             # check if we need to check this host,
-            next_check = datetime.datetime.strptime(aHost.next_check, self.time_format)
+            next_check = datetime.datetime.strptime(aHost.next_check, utils.TIME_FORMAT)
             if(next_check < now):
                 logging.debug(f"Checking {aHost.name}")
 
@@ -249,12 +248,12 @@ class HostMonitor:
                 host_check['id'] = aHost.id
 
                 # save the last and caclulate next check date
-                aHost.last_check = now.strftime(self.time_format)
+                aHost.last_check = now.strftime(utils.TIME_FORMAT)
                 host_check['last_check'] = aHost.last_check
 
                 #  add or subtract a bit from each check interval to help with system load
                 next_check = now + datetime.timedelta(minutes=(aHost.interval), seconds=randint(-60, 60))
-                aHost.next_check = next_check.strftime(self.time_format)
+                aHost.next_check = next_check.strftime(utils.TIME_FORMAT)
                 host_check['next_check'] = aHost.next_check
 
                 self.hosts[i] = aHost

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -13,6 +13,7 @@ from cerberus import Validator
 # full path to the running directory of the program
 DIR_PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 NAGIOS_PATH = "/usr/lib/nagios/plugins/"
+WATCHDOG_FILE = os.path.join(DIR_PATH, '.service_down')
 
 # valid status descriptions
 SERVICE_STATUSES = ["OK", "Warning", "Critical", "Unknown"]

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -24,6 +24,8 @@ UNCONFIRMED_STATE = "UNCONFIRMED"
 # allowed file types for web editor
 ALLOWED_EDITOR_TYPES = ('.yaml', '.py')
 
+# time format when converting datetime objects
+TIME_FORMAT = "%m-%d-%Y %I:%M%p"
 
 # custom YAML loader for !include syntax
 def custom_yaml_loader(loader, node):

--- a/watchdog.py
+++ b/watchdog.py
@@ -15,8 +15,10 @@ python3 watchdog.py -h
 
 """
 import argparse
+import datetime
 import json
 import logging
+import os.path
 import requests
 import sys
 import modules.utils as utils
@@ -74,7 +76,7 @@ else:
     logging.info("Trash Panda is down")
 
 # attempt to send notifications if configured
-if(args.config and return_code > 0):
+if(args.config and return_code > 0 and not os.path.exists(utils.WATCHDOG_FILE)):
     # load the config file
     yaml_check = utils.load_config_file(args.config)
 
@@ -88,6 +90,7 @@ if(args.config and return_code > 0):
     # create the notifier, if defined
     if('notifier' in yaml_file['config']):
         send_notification(yaml_file['config']['notifier'])
+        utils.write_file(utils.WATCHDOG_FILE, datetime.datetime.now())
 
 # exit
 sys.exit(return_code)

--- a/watchdog.py
+++ b/watchdog.py
@@ -1,0 +1,93 @@
+"""
+The watchdog is meant to check if the trash panda service is running and trigger a notification if it is not.
+Best practice would be to set this up on a cron schedule within the running OS. The up/down check uses the web service
+/api/health endpoint to determine if the monitoring system is running.
+
+The watchdog does need to read in the same configuration file information as the main dashboard process so that notifications will work properly.
+The port of the web service should also be given.
+Unlike the main program the watchdog does not need root priveledges to run.
+
+python3 watchdog.py -c /path/to/config.yaml -p 5000
+
+For a list of arguments use:
+
+python3 watchdog.py -h
+
+"""
+import argparse
+import json
+import logging
+import requests
+import sys
+import modules.utils as utils
+import modules.notifications as notifier
+
+
+def send_notification(notify_type):
+    notify = notifier.create_notifier(notify_type)
+
+    # send as critical notification
+    notify.notify_host("Trash Panda Service", 2)
+
+# parse the CLI args
+parser = argparse.ArgumentParser(description='Trash Panda Watchdog')
+parser.add_argument('-c', '--config', required=False,
+                    help="Path to the config file, notifications will be sent if given")
+parser.add_argument('-p', '--port', default=5000,
+                    help="Port number the web server runs on, %(default)d by default")
+parser.add_argument('-H', '--host', default="localhost",
+                    help="Host running the web service, %(default)s by default")
+parser.add_argument('-D', '--debug', action='store_true',
+                    help='If the program should run in debug mode')
+
+args = parser.parse_args()
+
+# setup the logger
+logLevel = 'INFO' if not args.debug else 'DEBUG'
+logHandlers = [logging.StreamHandler(sys.stdout)]
+logging.basicConfig(format="%(message)s",
+                    level=getattr(logging, logLevel),
+                    handlers=logHandlers)
+
+# check if the service is running
+service_url = f"http://{args.host}:{args.port}/api/health"
+return_code = 0
+try:
+    response = requests.get(service_url)
+
+    if(response.status_code == 200):
+        # attempt to load results
+        result = json.loads(response.text)
+
+        if('return_code' not in result or result['return_code'] > 0):
+            return_code = 2
+    else:
+        return_code = 2
+
+except Exception as e:
+    # any error set return code to Critical
+    return_code = 2
+
+if(return_code == 0):
+    logging.info("Trash Panda is running normally")
+else:
+    logging.info("Trash Panda is down")
+
+# attempt to send notifications if configured
+if(args.config and return_code > 0):
+    # load the config file
+    yaml_check = utils.load_config_file(args.config)
+
+    if(yaml_check['valid']):
+        yaml_file = yaml_check['yaml']
+    else:
+        logging.error("Error reading configuration file")
+        logging.error(yaml_check['errors'])
+        sys.exit(return_code)
+
+    # create the notifier, if defined
+    if('notifier' in yaml_file['config']):
+        send_notification(yaml_file['config']['notifier'])
+
+# exit
+sys.exit(return_code)


### PR DESCRIPTION
Adds the capability of running a __watchdog__ script that can be used to send notifications if the Trash Panda service stops working. This effectively is a monitor that watches the monitor. 

The idea is that it can be setup to run via an external timer (cron) and check the `/api/health` interface of the running web service. This service should throw an error condition if either a) it's not running or b) the monitor check process hasn't run in more than 2 minutes. The check process should look for new services to check every minute so this effectively monitors if something has triggered an error but not closed out the entire program loop. 

Once the watchdog finds that the web service is in a down state a notification can be sent. This creates a flag file `.service_down` that prevents further, annoying, notifications. Once the Trash Panda main service is restarted the flag file is deleted. 