### PR TITLE
Silence notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
-- added property `silence` to API status output. Set to true when host is still in silent mode
 - new http call `/api/silence_host/<id>/<minutes>` will put host in silent mode for the given number of minutes
+- added property `silence` to API status output. Set to true when host is still in silent mode
+- updated web interface so hosts can be put in silent mode and show silent mode status
 
 ## 3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## Unreleased
+
+### Added
+
+- added property `silence` to API status output. Set to true when host is still in silent mode
+- new http call `/api/silence_host/<id>/<minutes>` will put host in silent mode for the given number of minutes
+
 ## 3.3
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## 3.3
+
+### Added
+
+- added custom CSS for mobile devices
+
 ## 3.2
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ __/api/status__ - detailed listing of the status of each host
         "text": "11 days, 2:09:34\n"
       }
     ],
+    "silenced": false,
     "type": "switch"
   }
 ]
@@ -152,8 +153,18 @@ __/api/check_now/<host_id>__ - updates a given host's next check time to the cur
 
 ```
 {
-  "success": True
+  "success": true
   "next_check": "09-14-2022 09:44AM"
+}
+```
+
+__/api/silence_host/<host_id>/<minutes>__ - sets the given hosts silenced property to True for the given amount of minutes. This will silence any notifications for this time.
+
+```
+{
+  "is_silenced": true,
+  "success": true,
+  "until": "05-02-2023 01:31PM"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ optional arguments:
 
 Once running the dashboard page can be loaded. The landing page will display all currently configured hosts and their overall status. If the host is down, or any configured service unavailable, the overall status will change. This page is refreshed every __15 seconds__. Data will change depending on the update interval set when the program is loaded.
 
-Clicking on a host name will show you more information about that device. Individual services will be listed along with any output to indicate their current status. If configured, the management page for the host can also be launched from here.
+Clicking on a host name will show you more information about that device. Individual services will be listed along with any output to indicate their current status. From the host status page a check of all services can be forced, and notifications temporarily silenced. If configured, the management page for the host can also be launched from here.
 
 ### API
 
@@ -216,7 +216,7 @@ config:
 
 ### Notifications
 
-By default the system will not send any notifications, but there is support for some built-in notification methods. These can be defined in the `config` section of the YAML file by creating a `notifier` option. A notifier is loaded at startup and will send notifications on host status (up/down) changes or service status changes each time a check is run. Services must be in a CONFIRMED state before a notification is sent. Services are in an UNCONFIRMED state when either a warning or critical state has not reached the `service_check_attempts` threshold described above.
+By default the system will not send any notifications, but there is support for some built-in notification methods. These can be defined in the `config` section of the YAML file by creating a `notifier` option. A notifier is loaded at startup and will send notifications on host status (up/down) changes or service status changes each time a check is run. Services must be in a CONFIRMED state before a notification is sent. Services are in an UNCONFIRMED state when either a warning or critical state has not reached the `service_check_attempts` threshold described above. It is possible to temporarily silence notifications using the web interface or [API](#api).
 
 Additional notification methods can be defined by extending the `MonitorNotification` class. Built-in notification types are listed below.
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -152,6 +152,19 @@ def webapp_thread(port_number, config_file, debugMode=False, logHandlers=[]):
 
         return jsonify(result)
 
+    @app.route('/api/silence_host/<id>/<minutes>', methods=['GET'])
+    def silence_host(id, minutes):
+        until = datetime.datetime.now() + datetime.timedelta(minutes=int(minutes))
+        result = monitor.silence_host(id, until)
+
+        if(result['success']):
+            # update the host in the history DB as well
+            aHost = history.get_host(id)
+            aHost['silenced'] = result['is_silenced']
+            history.save_host(id, aHost)
+
+        return jsonify(result)
+
     @app.route('/editor', methods=['GET'])
     def editor():
         return render_template("editor.html", config_file=config_file, page_title='Config Editor')

--- a/dashboard.py
+++ b/dashboard.py
@@ -307,7 +307,10 @@ while 1:
     for host in status:
         # send notifications, if there are any
         if(notify is not None):
-            asyncio.run(check_notifications(notify, history.get_host(host['id']), host))
+            if(not host['silenced']):
+                asyncio.run(check_notifications(notify, history.get_host(host['id']), host))
+            else:
+                logging.info(f"{ host['name'] } is in silent mode, skipping notifications")
 
         # save the updated host
         history.save_host(host['id'], host)

--- a/dashboard.py
+++ b/dashboard.py
@@ -37,7 +37,7 @@ def signal_handler(signum, frame):
     sys.exit(0)
 
 
-def webapp_thread(port_number, config_file, debugMode=False, logHandlers=[]):
+def webapp_thread(port_number, config_file, notifier_configured, debugMode=False, logHandlers=[]):
     app = Flask(import_name="trash-panda", static_folder=os.path.join(utils.DIR_PATH, 'web', 'static'),
                 template_folder=os.path.join(utils.DIR_PATH, 'web', 'templates'))
 
@@ -78,7 +78,8 @@ def webapp_thread(port_number, config_file, debugMode=False, logHandlers=[]):
         result = _get_host(id)
 
         if(result is not None):
-            return render_template("host_status.html", host=result, page_title='Host Status')
+            # set if a notifier is configured to toggle silent mode controls
+            return render_template("host_status.html", host=result, page_title='Host Status', has_notifier=notifier_configured)
         else:
             flash('Host page not found', 'warning')
             return redirect('/')
@@ -296,7 +297,7 @@ monitor = HostMonitor(yaml_file)
 
 # start the web app
 logging.info('Starting Trash Panda Web Service')
-webAppThread = threading.Thread(name='Web App', target=webapp_thread, args=(args.port, args.file, True, logHandlers))
+webAppThread = threading.Thread(name='Web App', target=webapp_thread, args=(args.port, args.file, notify is not None, True, logHandlers))
 webAppThread.setDaemon(True)
 webAppThread.start()
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -152,7 +152,7 @@ def webapp_thread(port_number, config_file, debugMode=False, logHandlers=[]):
 
         return jsonify(result)
 
-    @app.route('/api/silence_host/<id>/<minutes>', methods=['GET'])
+    @app.route('/api/silence_host/<id>/<minutes>', methods=['POST'])
     def silence_host(id, minutes):
         until = datetime.datetime.now() + datetime.timedelta(minutes=int(minutes))
         result = monitor.silence_host(id, until)

--- a/modules/device.py
+++ b/modules/device.py
@@ -1,3 +1,5 @@
+import modules.utils as utils
+from datetime import datetime
 from slugify import slugify
 from modules.exceptions import ConfigValueMissingError
 
@@ -17,6 +19,7 @@ class Device:
     interval = 5
     check_attempts = 3
     services = []
+    silenced = False
 
     def __init__(self, host_def):
         self.type = host_def['type']
@@ -32,6 +35,7 @@ class Device:
         self.services = host_def['services']
         self.last_check = 0
         self.next_check = 0
+        self.silenced = datetime.now().strftime(utils.TIME_FORMAT)
 
         # set the address as part of the config
         self.config['address'] = self.address
@@ -41,7 +45,7 @@ class Device:
         can be serialized for JSON output"""
         result = {'type': self.type, 'id': self.id, 'name': self.name, 'address': self.address,
                   'icon': self.icon, 'info': self.info, 'interval': self.interval, 'service_check_attempts': self.check_attempts,
-                  'last_check': self.last_check, 'config': self.config}
+                  'last_check': self.last_check, 'config': self.config, 'silenced': self.is_silenced()}
 
         if(self.management_page is not None):
             result['management_page'] = self.management_page
@@ -53,6 +57,15 @@ class Device:
         Returns and array of all services this device will check
         """
         return self.services
+
+    def is_silenced(self):
+        """
+        Returns true/false if the host should currently be in silent mode.
+        This is true if the silenced timestamp is greater than the current time
+        """
+        silence_off = datetime.strptime(self.silenced, utils.TIME_FORMAT)
+
+        return silence_off > datetime.now()
 
 
 class HostType:

--- a/modules/monitor.py
+++ b/modules/monitor.py
@@ -274,6 +274,7 @@ class HostMonitor:
         return self.hosts[id] if id in self.hosts else None
 
     def check_now(self, id):
+        """sets the next check time on the host to now, forcing a check"""
         result = {"success": False}
 
         aHost = self.get_host(id)
@@ -285,6 +286,27 @@ class HostMonitor:
                 self.hosts[id] = aHost
 
                 result['next_check'] = aHost.next_check
+                result['success'] = True
+
+        return result
+
+    def silence_host(self, id, until):
+        """sets the silenced property on a host which will expire when the current time
+        exceeds the given datetime object
+        """
+        result = {"success": False}
+
+        aHost = self.get_host(id)
+
+        if(aHost is not None):
+            with self.lock:
+                # set the host as silenced until this datetime
+                aHost.silenced = until.strftime(utils.TIME_FORMAT)
+                self.hosts[id] = aHost
+
+                logging.debug(f"Silencing {id} until {aHost.silenced}")
+                result['is_silenced'] = aHost.is_silenced()
+                result['until'] = aHost.silenced
                 result['success'] = True
 
         return result

--- a/web/static/css/mobile.css
+++ b/web/static/css/mobile.css
@@ -19,6 +19,10 @@ p {
   text-align: right;
 }
 
+.div-inline{
+    display:inline-block;
+}
+
 #service_status td.row_1 {
   width: 20%;
 }
@@ -62,8 +66,13 @@ p {
     text-align: left;
   }
 
-  .service_check_btn, .create-file-btn, .nav-btn{
+  .service_check_btn, .create-file-btn, .silence_btn, .nav-btn{
+    margin-bottom:5px;
     display: block;
+    width: 100%;
+  }
+
+  .dropdown-mobile {
     width: 100%;
   }
 

--- a/web/templates/host_status.html
+++ b/web/templates/host_status.html
@@ -16,6 +16,38 @@ function check_now(id){
     }
   });
 }
+
+function silence_host(id, minutes){
+  $.post('/api/silence_host/' + id + '/' + minutes, function(data, status, request){
+    if(data.success){
+      if(data.is_silenced)
+      {
+        $('#js-success-alert').html("Host silenced until " + data.until);
+
+        $('#silence-btn').html('Silenced');
+        $('#silence-btn').addClass('btn-danger');
+        $('#silence-btn').removeClass('btn-warning');
+        $('#cancel-btn').show();
+      }
+      else
+      {
+        $('#js-success-alert').html("Silent mode canceled");
+
+        $('#silence-btn').html('Silence');
+        $('#silence-btn').addClass('btn-warning');
+        $('#silence-btn').removeClass('btn-danger');
+        $('#cancel-btn').hide();
+      }
+
+      $('#js-success-alert').show().delay(3000).fadeOut();
+    }
+    else {
+      $('#js-error-alert').html("Error silencing host");
+      $('#js-error-alert').show().delay(3000).fadeOut();
+    }
+  });
+}
+
 </script>
 {% endblock %}
 {% block content %}
@@ -49,7 +81,20 @@ function check_now(id){
 <div class="container">
   {% if('services' in host): %}
   <div class="mt-2 pt-1" align="right">
-    <button class="btn btn-primary service_check_btn" onclick="check_now('{{host['id']}}')">Check Now</button>
+  <button class="btn btn-primary service_check_btn" onclick="check_now('{{host['id']}}')">Check Now</button>
+  <div class="dropdown div-inline silence_btn">
+    {% if host['silenced'] %}
+    <button id="silence-btn" class="btn btn-danger dropdown-toggle silence_btn" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Silenced</button>
+    {% else %}
+    <button id="silence-btn" class="btn btn-warning dropdown-toggle silence_btn" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Silence</button>
+    {% endif %}
+    <div class="dropdown-menu dropdown-mobile" aria-labelledby="dropdownMenuButton">
+      <button class="dropdown-item" type="button" id="cancel-btn" style="{{ 'display:none' if not host['silenced'] else '' }}" onClick="silence_host('{{host['id']}}', -1)">Cancel</button>
+      <button class="dropdown-item" type="button" onClick="silence_host('{{host['id']}}', 30)">30 Min</button>
+      <button class="dropdown-item" type="button" onClick="silence_host('{{host['id']}}', 60)">1 Hour</button>
+      <button class="dropdown-item" type="button" onClick="silence_host('{{host['id']}}', 120)">2 Hours</button>
+    </div>
+  </div>
   </div>
   <table class="table table-striped mt-3" id="service_status">
     <thead>

--- a/web/templates/host_status.html
+++ b/web/templates/host_status.html
@@ -53,7 +53,6 @@ function silence_host(id, minutes){
 {% block content %}
 {% set current_status = ['text-success', 'text-warning', 'text-danger', 'text-secondary'] %}
 {% set status_text = ['', '', '', 'text-secondary'] %}
-
 <div class="container">
   <div class="row">
     <div class="col-lg-8">
@@ -82,6 +81,7 @@ function silence_host(id, minutes){
   {% if('services' in host): %}
   <div class="mt-2 pt-1" align="right">
   <button class="btn btn-primary service_check_btn" onclick="check_now('{{host['id']}}')">Check Now</button>
+  {% if has_notifier %}
   <div class="dropdown div-inline silence_btn">
     {% if host['silenced'] %}
     <button id="silence-btn" class="btn btn-danger dropdown-toggle silence_btn" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Silenced</button>
@@ -95,6 +95,7 @@ function silence_host(id, minutes){
       <button class="dropdown-item" type="button" onClick="silence_host('{{host['id']}}', 120)">2 Hours</button>
     </div>
   </div>
+  {% endif %}
   </div>
   <table class="table table-striped mt-3" id="service_status">
     <thead>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -45,14 +45,21 @@ function load_status(){
       row.append(td.clone().text(h.last_check).addClass('hide-md'));
       row.append(td.clone().text(h.next_check).addClass('hide-md'));
 
+      silent_mode = '';
+      if(h.silenced)
+      {
+        silent_mode = $('<i>');
+        silent_mode.attr('class','mdi mdi-volume-off icon-sm icon-inline ml-1');
+      }
+
       if(h.overall_status == 0){
-        row.append(td.clone().text("OK").addClass('text-success'));
+        row.append(td.clone().text("OK").addClass('text-success').append(silent_mode));
       }
       else if(h.overall_status == 1){
-        row.append(td.clone().text("Warning").addClass('text-warning'));
+        row.append(td.clone().text("Warning").addClass('text-warning').append(silent_mode));
       }
       else {
-        row.append(td.clone().text("Critical").addClass('text-danger'));
+        row.append(td.clone().text("Critical").addClass('text-danger').append(silent_mode));
       }
 
       table.append(row);


### PR DESCRIPTION
This will close #20 

Each host now has an additional property `silenced` that evaluates to true or false. When set via the API any host can be put in silent mode for a given number of minutes. Defaults from the web UI are 30, 60, or 120. This sets a timestamp on the host that suppresses any notifications until the time period expires. Service checks do continue to run during this time. 

Within the web UI the host is shown as in silent mode on both the default landing page and status detail page. Silent mode can be canceled as well. This is done by sending -1 to the API. Controls for this only show up in the web interface if a notification type has been setup. 

### Limitations

The biggest limitation from a usability standpoint is that the `silenced` property  will tell you if a host is silenced but not the expiration time. This time is kept internally but not exposed to the user. In keeping with the simple nature of this tool I didn't want to add another additional property to keep track of this to the API. 

Another limitation is that on restart all silent mode settings are reset back to false. These are not stored persistently across restarts. Again, this wasn't seen as a major issue worth revamping a lot of the internal code to avoid. 