### PR TITLE
Updated Notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,9 @@ config:
 
 ### Notifications
 
-By default the system will not send any notifications, but there is support for some built-in notification methods. These can be defined in the `config` section of the YAML file by creating a `notifications` option. One, or more, notification types can be specified. Each notification type is loaded at startup and will send notifications on host status (up/down) changes or service status changes each time a check is run. Services must be in a CONFIRMED state before a notification is sent. Services are in an UNCONFIRMED state when either a warning or critical state has not reached the `service_check_attempts` threshold described above. It is possible to temporarily silence notifications using the web interface or [API](#api).
+By default the system will not send any notifications, but there is support for some built-in notification methods. These can be defined in the `config` section of the YAML file by creating a `notifications` option. One, or more, notification types can be specified. By default notifications will be sent to all configured type, however a `primary` type can be specified that will be used by default unless another is specified at the host or service level. A special `none` type can also be used to specify no notifications. This is useful at the host or service level.
+
+Notifications are triggered on host status (up/down) changes or service status changes each time a check is run. Services must be in a CONFIRMED state before a notification is sent. Services are in an UNCONFIRMED state when either a warning or critical state has not reached the `service_check_attempts` threshold described above. It is possible to temporarily silence notifications using the web interface or [API](#api).
 
 Additional notification types can be defined by extending the `MonitorNotification` class. Built-in notification types are listed below.
 
@@ -224,20 +226,23 @@ __Log Notifier__ - writes all notification messages directly to the log. Optiona
 ```
 config:
   notifications:
-    - type: log
-      args:
-        path: /path/to/custom.log
-        propagate: True  # controls if notifications also written to root logger
+    types:
+      - type: log
+        args:
+          path: /path/to/custom.log
+          propagate: True  # controls if notifications also written to root logger
 ```
 
 __Pushover Notifier__ - sends messages through the [Pushover Notification Service](https://pushover.net/). A valid application key and user key are needed for your account and can be generated using [their instructions](https://pushover.net/api).
 ```
 config:
   notifications:
-    - type: pushover
-      args:
-        api_key: pushover_api_key
-        user_key: pushover_user_key
+    primary: none
+    types:
+      - type: pushover
+        args:
+          api_key: pushover_api_key
+          user_key: pushover_user_key
 ```
 
 ## Services

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ __/api/status__ - detailed listing of the status of each host
         "name": "Switch Uptime",
         "return_code": 1,
         "state": "UNCONFIRMED",
-        "text": "11 days, 2:09:34\n"
+        "text": "11 days, 2:09:34\n",
+        "notifier": "none"
       }
     ],
     "silenced": false,
@@ -216,7 +217,7 @@ config:
 
 ### Notifications
 
-By default the system will not send any notifications, but there is support for some built-in notification methods. These can be defined in the `config` section of the YAML file by creating a `notifications` option. One, or more, notification types can be specified. By default notifications will be sent to all configured type, however a `primary` type can be specified that will be used by default unless another is specified at the host or service level. A special `none` type can also be used to specify no notifications. This is useful at the host or service level.
+By default the system will not send any notifications, but there is support for some built-in notification methods. These can be defined in the `config` section of the YAML file by creating a `notifications` option. One, or more, notification types can be specified. By default notifications will be sent to `all` configured types, however a `primary` type can be specified that will be used by default unless another is specified at the host or service level. A special `none` type can also be used to specify no notifications. This is useful at the host or service level.
 
 Notifications are triggered on host status (up/down) changes or service status changes each time a check is run. Services must be in a CONFIRMED state before a notification is sent. Services are in an UNCONFIRMED state when either a warning or critical state has not reached the `service_check_attempts` threshold described above. It is possible to temporarily silence notifications using the web interface or [API](#api).
 
@@ -226,6 +227,7 @@ __Log Notifier__ - writes all notification messages directly to the log. Optiona
 ```
 config:
   notifications:
+    primary: all
     types:
       - type: log
         args:

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ web_server:
   name: Web Server
   icon: server
   interval: 10
+  notifier: log
   service_check_attempts: 2
   config:
     virtual_host:
@@ -287,7 +288,11 @@ web_server:
 
 The above defines a device type of __web_server__ that can be implemented by a host. The host must have the variable __virtual_host__ present, as it's used in the http service config; and also will automatically have the service check __http__ assigned to it.
 
-Also notice the __interval__ value. This is optional. By default the global interval will be used, but individual device types, or individual hosts, can set their own.  
+Also of note are some optional variables.
+
+* __interval__: By default the global interval will be used, but individual device types, or individual hosts, can set their own.
+* __notifier__: Again, by default the global notification type will be used but hosts types can set their own. This will apply to the host and all services under it.
+* __service_check_attempts__: Override the global service check value with a custom value for this host
 
 ## Host Definitions
 
@@ -310,7 +315,7 @@ services:
       path: "/admin"
 ```
 
-The above host will inherit the services from the __web_server__ type above but it also adds an additional http check on port 5000 for a different site. Both of these will be checked at run time.
+The above host will inherit the services from the __web_server__ type above but it also adds an additional http check on port 5000 for a different site. Both of these will be checked at run time. Any variables available within the Host Type can be overridden by an individual host as well (icon, check interval, etc).
 
 ### Optional Attributes
 

--- a/README.md
+++ b/README.md
@@ -216,28 +216,28 @@ config:
 
 ### Notifications
 
-By default the system will not send any notifications, but there is support for some built-in notification methods. These can be defined in the `config` section of the YAML file by creating a `notifications` option. A notifier is loaded at startup and will send notifications on host status (up/down) changes or service status changes each time a check is run. Services must be in a CONFIRMED state before a notification is sent. Services are in an UNCONFIRMED state when either a warning or critical state has not reached the `service_check_attempts` threshold described above. It is possible to temporarily silence notifications using the web interface or [API](#api).
+By default the system will not send any notifications, but there is support for some built-in notification methods. These can be defined in the `config` section of the YAML file by creating a `notifications` option. One, or more, notification types can be specified. Each notification type is loaded at startup and will send notifications on host status (up/down) changes or service status changes each time a check is run. Services must be in a CONFIRMED state before a notification is sent. Services are in an UNCONFIRMED state when either a warning or critical state has not reached the `service_check_attempts` threshold described above. It is possible to temporarily silence notifications using the web interface or [API](#api).
 
-Additional notification methods can be defined by extending the `MonitorNotification` class. Built-in notification types are listed below.
+Additional notification types can be defined by extending the `MonitorNotification` class. Built-in notification types are listed below.
 
 __Log Notifier__ - writes all notification messages directly to the log. Optionally the `path` argument can be used to specify a custom log path for notification messages.
 ```
 config:
   notifications:
-    type: log
-    args:
-      path: /path/to/custom.log
-      propagate: True  # controls if notifications also written to root logger
+    - type: log
+      args:
+        path: /path/to/custom.log
+        propagate: True  # controls if notifications also written to root logger
 ```
 
 __Pushover Notifier__ - sends messages through the [Pushover Notification Service](https://pushover.net/). A valid application key and user key are needed for your account and can be generated using [their instructions](https://pushover.net/api).
 ```
 config:
   notifications:
-    type: pushover
-    args:
-      api_key: pushover_api_key
-      user_key: pushover_user_key
+    - type: pushover
+      args:
+        api_key: pushover_api_key
+        user_key: pushover_user_key
 ```
 
 ## Services

--- a/README.md
+++ b/README.md
@@ -216,14 +216,14 @@ config:
 
 ### Notifications
 
-By default the system will not send any notifications, but there is support for some built-in notification methods. These can be defined in the `config` section of the YAML file by creating a `notifier` option. A notifier is loaded at startup and will send notifications on host status (up/down) changes or service status changes each time a check is run. Services must be in a CONFIRMED state before a notification is sent. Services are in an UNCONFIRMED state when either a warning or critical state has not reached the `service_check_attempts` threshold described above. It is possible to temporarily silence notifications using the web interface or [API](#api).
+By default the system will not send any notifications, but there is support for some built-in notification methods. These can be defined in the `config` section of the YAML file by creating a `notifications` option. A notifier is loaded at startup and will send notifications on host status (up/down) changes or service status changes each time a check is run. Services must be in a CONFIRMED state before a notification is sent. Services are in an UNCONFIRMED state when either a warning or critical state has not reached the `service_check_attempts` threshold described above. It is possible to temporarily silence notifications using the web interface or [API](#api).
 
 Additional notification methods can be defined by extending the `MonitorNotification` class. Built-in notification types are listed below.
 
 __Log Notifier__ - writes all notification messages directly to the log. Optionally the `path` argument can be used to specify a custom log path for notification messages.
 ```
 config:
-  notifier:
+  notifications:
     type: log
     args:
       path: /path/to/custom.log
@@ -233,7 +233,7 @@ config:
 __Pushover Notifier__ - sends messages through the [Pushover Notification Service](https://pushover.net/). A valid application key and user key are needed for your account and can be generated using [their instructions](https://pushover.net/api).
 ```
 config:
-  notifier:
+  notifications:
     type: pushover
     args:
       api_key: pushover_api_key

--- a/dashboard.py
+++ b/dashboard.py
@@ -285,8 +285,8 @@ else:
 
 # create the notifier, if needed
 notify = None
-if('notifier' in yaml_file['config']):
-    notify = notifier.create_notifier(yaml_file['config']['notifier'])
+if('notifications' in yaml_file['config']):
+    notify = notifier.create_notifier(yaml_file['config']['notifications'])
 
 # check if the watchdog file was created
 if(os.path.exists(utils.WATCHDOG_FILE)):

--- a/dashboard.py
+++ b/dashboard.py
@@ -286,7 +286,8 @@ else:
 # create the notifier, if needed
 notify = None
 if('notifications' in yaml_file['config']):
-    notify = NotificationGroup(yaml_file['config']['notifications'])
+    notify = NotificationGroup(yaml_file['config']['notifications']['primary'],
+                               yaml_file['config']['notifications']['types'])
 
 # check if the watchdog file was created
 if(os.path.exists(utils.WATCHDOG_FILE)):

--- a/dashboard.py
+++ b/dashboard.py
@@ -22,10 +22,10 @@ import time
 import os
 import os.path
 import modules.utils as utils
-import modules.notifications as notifier
 from natsort import natsorted
 from modules.monitor import HostMonitor
 from modules.history import HostHistory
+from modules.notifications import NotificationGroup
 from flask import Flask, flash, render_template, jsonify, redirect, request, Response
 
 history = HostHistory()
@@ -286,7 +286,7 @@ else:
 # create the notifier, if needed
 notify = None
 if('notifications' in yaml_file['config']):
-    notify = notifier.create_notifier(yaml_file['config']['notifications'])
+    notify = NotificationGroup(yaml_file['config']['notifications'])
 
 # check if the watchdog file was created
 if(os.path.exists(utils.WATCHDOG_FILE)):

--- a/install/schema.yaml
+++ b/install/schema.yaml
@@ -1,3 +1,13 @@
+# first define some lists to re-use later
+
+# full list of allowed notification types
+notification_types:
+  allowed: &notification_types
+    - all
+    - none
+    - pushover
+    - log
+
 # schema for the yaml layout, validated at startup
 config:
   required: False
@@ -33,11 +43,7 @@ config:
         primary:
           required: False
           type: string
-          allowed:
-            - all
-            - none
-            - pushover
-            - log
+          allowed: *notification_types
           default: all
         types:
           type: list
@@ -96,6 +102,10 @@ types:
       interval:
         required: False
         type: integer
+      notifier:
+        required: False
+        type: string
+        allowed: *notification_types
       service_check_attempts:
         required: False
         type: integer
@@ -126,6 +136,10 @@ types:
             name:
               required: True
               type: string
+            notifier:
+              required: False
+              type: string
+              allowed: *notification_types
             service_url:
               required: False
               type: string
@@ -156,6 +170,10 @@ hosts:
       interval:
         required: False
         type: integer
+      notifier:
+        required: False
+        type: string
+        allowed: *notification_types
       service_check_attempts:
         required: False
         type: integer
@@ -188,6 +206,10 @@ hosts:
             name:
               required: True
               type: string
+            notifier:
+              required: False
+              type: string
+              allowed: *notification_types
             service_url:
               required: False
               type: string

--- a/install/schema.yaml
+++ b/install/schema.yaml
@@ -28,24 +28,26 @@ config:
         type: string
     notifications:
       required: False
-      type: dict
+      type: list
       schema:
-        type:
-          required: True
-          type: string
-          allowed:
-            - log
-            - pushover
-        args:
-          required: False
-          type: dict
-          valueschema:
-            type:
-              - string
-              - integer
-              - boolean
-          default:
-            args: none
+        type: dict
+        schema:
+          type:
+            required: True
+            type: string
+            allowed:
+              - log
+              - pushover
+          args:
+            required: False
+            type: dict
+            valueschema:
+              type:
+                - string
+                - integer
+                - boolean
+            default:
+              args: none
 services:
   required: True
   type: dict

--- a/install/schema.yaml
+++ b/install/schema.yaml
@@ -26,7 +26,7 @@ config:
       valueschema:
         required: True
         type: string
-    notifier:
+    notifications:
       required: False
       type: dict
       schema:

--- a/install/schema.yaml
+++ b/install/schema.yaml
@@ -28,26 +28,38 @@ config:
         type: string
     notifications:
       required: False
-      type: list
+      type: dict
       schema:
-        type: dict
-        schema:
-          type:
-            required: True
-            type: string
-            allowed:
-              - log
-              - pushover
-          args:
-            required: False
+        primary:
+          required: False
+          type: string
+          allowed:
+            - all
+            - none
+            - pushover
+            - log
+          default: all
+        types:
+          type: list
+          schema:
             type: dict
-            valueschema:
+            schema:
               type:
-                - string
-                - integer
-                - boolean
-            default:
-              args: none
+                required: True
+                type: string
+                allowed:
+                  - log
+                  - pushover
+              args:
+                required: False
+                type: dict
+                valueschema:
+                  type:
+                    - string
+                    - integer
+                    - boolean
+                default:
+                  args: none
 services:
   required: True
   type: dict

--- a/modules/device.py
+++ b/modules/device.py
@@ -30,6 +30,7 @@ class Device:
         self.info = host_def['info']
         self.icon = host_def['icon']
         self.interval = host_def['interval']
+        self.notifier = host_def['notifier']
         self.check_attempts = host_def['service_check_attempts']
         self.config = host_def['config']
         self.services = host_def['services']
@@ -47,8 +48,12 @@ class Device:
                   'icon': self.icon, 'info': self.info, 'interval': self.interval, 'service_check_attempts': self.check_attempts,
                   'last_check': self.last_check, 'config': self.config, 'silenced': self.is_silenced()}
 
+        # set these values if they exist
         if(self.management_page is not None):
             result['management_page'] = self.management_page
+
+        if(self.notifier is not None):
+            result['notifier'] = self.notifier
 
         return result
 
@@ -78,6 +83,7 @@ class HostType:
     info = ""
     icon = 'devices'
     interval = 5
+    notifier = None
     check_attempts = 3
     config = {}
     services = []
@@ -86,6 +92,7 @@ class HostType:
         self.type = type_name
         self.name = type_def['name']
         self.interval = default_interval if 'interval' not in type_def else type_def['interval']
+        self.notifier = None if 'notifier' not in type_def else type_def['notifier']
         self.check_attempts = default_attempts if 'service_check_attempts' not in type_def else type_def['service_check_attempts']
 
         if('info' in type_def):
@@ -124,6 +131,9 @@ class HostType:
 
         if('interval' not in device_def):
             device_def['interval'] = self.interval
+
+        if('notifier' not in device_def):
+            device_def['notifier'] = self.notifier
 
         if('service_check_attempts' not in device_def):
             device_def['service_check_attempts'] = self.check_attempts

--- a/modules/notifications.py
+++ b/modules/notifications.py
@@ -3,16 +3,34 @@ import modules.utils as utils
 from pushover import Client
 
 
-def create_notifier(notifier):
-    """Create a notifier class using the given config"""
-    result = None
+class NotificationGroup:
+    """Contains a group of notification objects that can be triggered all at once"""
+    notifiers = []
 
-    if(notifier['type'] == 'log'):
-        result = LogNotification(notifier['args'])
-    elif(notifier['type'] == 'pushover'):
-        result = PushoverNotification(notifier['args'])
+    def __init__(self, notify_types):
+        """notify_types should be a list of notification types from the config"""
+        # go through the list and create each notifier
+        for n in notify_types:
+            self.notifiers.append(self.__create_notifier(n))
 
-    return result
+    def __create_notifier(self, notifier):
+        """Create a notifier class using the given config"""
+        result = None
+
+        if(notifier['type'] == 'log'):
+            result = LogNotification(notifier['args'])
+        elif(notifier['type'] == 'pushover'):
+            result = PushoverNotification(notifier['args'])
+
+        return result
+
+    def notify_host(self, host, status):
+        for n in self.notifiers:
+            n.notify_host(host, status)
+
+    def notify_service(self, host, service):
+        for n in self.notifiers:
+            n.notify_service(host, service)
 
 
 class MonitorNotification:

--- a/modules/notifications.py
+++ b/modules/notifications.py
@@ -48,13 +48,20 @@ class NotificationGroup:
             # use only the type specified
             return [self.notifiers[type]]
 
-    def notify_host(self, host, status, type=None):
+    def notify_host(self, host, status):
+
+        # determine the type
+        type = host['notifier'] if 'notifier' in host else self.default
 
         # send to any notifier in this group
         for n in self.__get_notify_group(type):
             n.notify_host(host, status)
 
-    def notify_service(self, host, service, type=None):
+    def notify_service(self, host, service):
+
+        # determine the type
+        type = service['notifier'] if 'notifier' in service else (host['notifier'] if 'notifier' in host else self.default)
+
         for n in self.__get_notify_group(type):
             n.notify_service(host, service)
 


### PR DESCRIPTION
This adds support for more notifications as outlined in #22. Changes made include: 

1. The ability to add an array of notification types instead of just one notification type. These are loaded on startup. 
2. By default all notification types are sent to but a default primary type can be specified in the config. Special keywords `all` and `none` specify either all types or no notification respectively. 
3. Notification types can be specified at either the host or service level in either the host type configuration or the individual host configuration. Doing this requires a `notify` parameter to be set at either the host level (trickles down to services) or at an individual service level. 