### PR TITLE
Pushover Fix and Minor Enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## 6.1
+
+### Changed
+
+- migrated Pushover to use [chump](https://chump.readthedocs.io/en/latest/) instead of python-pushover library
+
 ## 6.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## 6.1
 
+### Added
+
+- The host of the Redis database can be passed in with a `--database` argument at runtime
+
 ### Changed
 
 - migrated Pushover to use [chump](https://chump.readthedocs.io/en/latest/) instead of python-pushover library
+- DB can be set at runtime, no longer assumed localhost
 
 ## 6.0
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A full list of arguments can be found by using the `-h` flag.
 ```
 python3 dashboard.py -h
 
-usage: dashboard.py [-h] [-c CONFIG] [-f FILE] [-p PORT] [-D]
+usage: dashboard.py [-h] [-c CONFIG] [-f FILE] [-p PORT] [-d DATABASE] [-D]
 
 Trash Panda
 
@@ -68,6 +68,8 @@ optional arguments:
   -f FILE, --file FILE  Path to the config file for the host data,
                         conf/monitor.json by default
   -p PORT, --port PORT  Port number to run the web server on, 5000 by default
+  -d DATABASE, --database DATABASE
+                        IP or hostname of Redis database, 127.0.0.1 by default
   -D, --debug           If the program should run in debug mode
 
 ```

--- a/dashboard.py
+++ b/dashboard.py
@@ -412,7 +412,7 @@ if('notifications' in yaml_file['config']):
                                yaml_file['config']['notifications']['types'])
 
 logging.info('Starting monitoring check daemon')
-monitor = HostMonitor(yaml_file)
+monitor = HostMonitor(history, yaml_file)
 
 # start the web app
 logging.info('Starting Trash Panda Web Service')

--- a/dashboard.py
+++ b/dashboard.py
@@ -375,6 +375,8 @@ parser.add_argument('-f', '--file', default='conf/monitor.yaml',
                     help="Path to the config file for the host data, %(default)s by default")
 parser.add_argument('-p', '--port', default=5000,
                     help="Port number to run the web server on, %(default)d by default")
+parser.add_argument('-d', '--database', default="127.0.0.1",
+                    help="IP or hostname of Redis database, %(default)s by default")
 parser.add_argument('-D', '--debug', action='store_true',
                     help='If the program should run in debug mode')
 
@@ -394,7 +396,7 @@ logging.basicConfig(datefmt='%m/%d %H:%M:%S',
 logging.getLogger('asyncio').setLevel(logging.WARNING)  # only show warning or above from this module
 
 # connect to redis DB
-history = HostHistory()
+history = HostHistory(args.database)
 
 # load the config file
 yaml_check = utils.load_config_file(args.file)

--- a/dashboard.py
+++ b/dashboard.py
@@ -29,8 +29,6 @@ from modules.notifications import NotificationGroup
 from flask import Flask, flash, render_template, jsonify, redirect, request, Response
 from slugify import slugify
 
-history = HostHistory()
-
 
 # function to handle when the is killed and exit gracefully
 def signal_handler(signum, frame):
@@ -394,6 +392,9 @@ logging.basicConfig(datefmt='%m/%d %H:%M:%S',
                     level=getattr(logging, logLevel),
                     handlers=logHandlers)
 logging.getLogger('asyncio').setLevel(logging.WARNING)  # only show warning or above from this module
+
+# connect to redis DB
+history = HostHistory()
 
 # load the config file
 yaml_check = utils.load_config_file(args.file)

--- a/install/Install.md
+++ b/install/Install.md
@@ -1,7 +1,6 @@
 # Install
 
-Instructions to install the system with all required libraries and binary files.
-
+Instructions to install the system with all required libraries and binary files. This installation will run both the service and database on the same machine. Installation of the Redis database can be done on a different device. 
 
 ### Initial OS setup and Python library install
 

--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -1,10 +1,10 @@
 asyncio
 cerberus
+chump
 configargparse
 Flask
 markdown
 natsort
-python-pushover
 pythonping
 python-slugify
 redis

--- a/modules/history.py
+++ b/modules/history.py
@@ -10,8 +10,8 @@ class HostHistory:
 
     db = None
 
-    def __init__(self):
-        self.db = redis.Redis('127.0.0.1', decode_responses=True)
+    def __init__(self, db_host):
+        self.db = redis.Redis(db_host, decode_responses=True)
 
     def save_last_check(self):
         """sets the last check time using the current time as a unix timestamp"""

--- a/modules/monitor.py
+++ b/modules/monitor.py
@@ -32,12 +32,12 @@ class HostMonitor:
     _jinja = None
     lock = Lock()  # lock for host updating functions
 
-    def __init__(self, yaml_file):
+    def __init__(self, history, yaml_file):
         # create the host type and services definitions, load history
         self.types = self.__create_types(yaml_file['types'], yaml_file['config']['default_interval'], yaml_file['config']['service_check_attempts'])
         self.services = yaml_file['services']
         self.hosts = {}
-        self.history = HostHistory()
+        self.history = history
 
         # load jinja environment
         self._jinja = jinja2.Environment()

--- a/modules/monitor.py
+++ b/modules/monitor.py
@@ -162,7 +162,7 @@ class HostMonitor:
                 # add in the label and unit of measure
                 p_id = slugify(first_key[0]) if slugify(first_key[0].strip()) != '' else 'root'
                 mapping['id'] = f"{service_id}-{p_id}"
-                mapping['label'] = first_key[0].replace("'","")
+                mapping['label'] = first_key[0].replace("'", "")
 
                 # only add if it exists
                 if(unit_of_measure != ""):

--- a/modules/notifications.py
+++ b/modules/notifications.py
@@ -152,6 +152,7 @@ class PushoverNotification(MonitorNotification):
     """
     client = None
     user_key = None
+
     def __init__(self, args):
         super().__init__('pushover')
 

--- a/modules/notifications.py
+++ b/modules/notifications.py
@@ -3,7 +3,7 @@ import requests
 import smtplib
 import ssl
 import modules.utils as utils
-from pushover import Client
+from chump import Application
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 
@@ -144,21 +144,24 @@ class LogNotification(MonitorNotification):
 class PushoverNotification(MonitorNotification):
     """Sends notification messages through the Pushover messenger service
     https://pushover.net/
-    https://pypi.org/project/python-pushover/
+    https://chump.readthedocs.io/en/latest/
 
     Custom config:
     * application key
     * user identifiction key
     """
     client = None
-
+    user_key = None
     def __init__(self, args):
         super().__init__('pushover')
 
-        self.client = Client(args['user_key'], api_token=args['api_key'])
+        self.client = Application(args['api_key'])
+        self.user_key = args['user_key']
 
     def _send_message(self, message):
-        self.client.send_message(message, title="Monitoring Notification")
+        user = self.client.get_user(self.user_key)
+
+        user.send_message(message, title="Monitoring Notification")
 
 
 class EmailNotification(MonitorNotification):

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -68,7 +68,7 @@
              <a href="/guide" class="mr-3"><i class="mdi mdi-book-open-page-variant-outline icon-2x"></i></a>
              <a href="https://github.com/robweber/trash-panda"><i class="mdi mdi-github icon-2x"></i></a>
            </p>
-           <p>Version 6.0</p>
+           <p>Version 6.1</p>
         </footer>
     </body>
 </html>


### PR DESCRIPTION
Main fix here is to replace the python-pushover library with the chump library. python-pushover is fairly old and was not installing properly on newer systems. 

Another minor enhancement is the ability to pass in the Redis database host or IP address via a command line argument. This was hardcoded to the localhost previously. Now the Redis DB could live on a different machine. 